### PR TITLE
Fix/ios compatibility with static frameworks (#26)

### DIFF
--- a/OndatoSdkReactNative.podspec
+++ b/OndatoSdkReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "OndatoSDK", "= 2.6.8"
+  s.dependency "OndatoSDK", "= 2.6.9"
 
   install_modules_dependencies(s)
 end

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ You can also **provide your own translations** by overriding [Ondato's string ke
     ```groovy
     dependencies {
       // ... other dependencies
-      implementation("com.kyc.ondato:screen-recorder:2.6.7")
+      implementation("com.kyc.ondato:recorder:2.6.7")
       // and/or
       implementation("com.kyc.ondato:nfc-reader:2.6.7")
     }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To create a new Expo project, see the [Get Started](https://docs.expo.dev/get-st
 Install Ondato SDK React Native:
 
 ```bash
-npx expo install https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.8-newarch.0/osrn-v2.6.8-newarch.0.tgz
+npx expo install https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.9-newarch/osrn-v2.6.9-newarch.tgz
 ```
 
 ### Configure Ondato SDK with config plugin
@@ -140,9 +140,9 @@ npx expo run:ios
 ### Installation
 
 ```sh
-yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.8-newarch.0/osrn-v2.6.8-newarch.0.tgz
+yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.9-newarch/osrn-v2.6.9-newarch.tgz
 # or
-npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.8-newarch.0/osrn-v2.6.8-newarch.0.tgz
+npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.9-newarch/osrn-v2.6.9-newarch.tgz
 ```
 
 #### iOS Specific Setup
@@ -329,9 +329,9 @@ You can also **provide your own translations** by overriding [Ondato's string ke
 1.  Add the relevant pods to your `Podfile`:
     ```ruby
     # Podfile
-    pod 'OndatoSDK', '= 2.6.8'
+    pod 'OndatoSDK', '= 2.6.9'
     # and/or
-    pod 'OndatoScreenRecorder', '= 2.6.8'
+    pod 'OndatoScreenRecorder', '= 2.6.9'
     ```
 2.  Add the necessary permissions to your `Info.plist`:
     ```xml

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -108,7 +108,7 @@ android {
 }
 
 dependencies {
-  implementation("com.kyc.ondato:screen-recorder:2.6.7")
+  implementation("com.kyc.ondato:recorder:2.6.7")
   implementation("com.kyc.ondato:nfc-reader:2.6.7")
 
   // The version of react-native is set by the React Native Gradle Plugin

--- a/example/ios/OndatoSdkReactNativeExample.xcodeproj/project.pbxproj
+++ b/example/ios/OndatoSdkReactNativeExample.xcodeproj/project.pbxproj
@@ -193,13 +193,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OndatoSdkReactNativeExample/Pods-OndatoSdkReactNativeExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OndatoSdkReactNativeExample/Pods-OndatoSdkReactNativeExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -236,13 +232,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OndatoSdkReactNativeExample/Pods-OndatoSdkReactNativeExample-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OndatoSdkReactNativeExample/Pods-OndatoSdkReactNativeExample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -25,8 +25,8 @@ target 'OndatoSdkReactNativeExample' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'OndatoSDK', '= 2.6.8'
-  pod 'OndatoScreenRecorder', '= 2.6.8'
+  pod 'OndatoNFC', '= 2.6.9'
+  pod 'OndatoScreenRecorder', '= 2.6.9'
 
 
   post_install do |installer|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,16 +8,17 @@ PODS:
   - hermes-engine (0.81.0):
     - hermes-engine/Pre-built (= 0.81.0)
   - hermes-engine/Pre-built (0.81.0)
-  - OndatoScreenRecorder (2.6.8)
-  - OndatoSDK (2.6.8)
-  - OndatoSdkReactNative (2.6.8-newarch.0):
+  - OndatoNFC (2.6.9)
+  - OndatoScreenRecorder (2.6.9)
+  - OndatoSDK (2.6.9)
+  - OndatoSdkReactNative (2.6.9-newarch):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - OndatoSDK (= 2.6.8)
+    - OndatoSDK (= 2.6.9)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2352,8 +2353,8 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - OndatoScreenRecorder (= 2.6.8)
-  - OndatoSDK (= 2.6.8)
+  - OndatoNFC (= 2.6.9)
+  - OndatoScreenRecorder (= 2.6.9)
   - OndatoSdkReactNative (from `../..`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -2425,6 +2426,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - OndatoNFC
     - OndatoScreenRecorder
     - OndatoSDK
     - SocketRocket
@@ -2586,9 +2588,10 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: e7491a2038f2618c8cd444ed411a6deb350a3742
-  OndatoScreenRecorder: 3f4d478eb43d3beb4fe71de99171960416958bfb
-  OndatoSDK: 8fba71ee2a1d950ea30899370a858028b8f82ec5
-  OndatoSdkReactNative: c34e5e5a9a041d093ed5fb48009313ee7c58e5e2
+  OndatoNFC: b048eb5b7c40c459b5a5726ba4161b363ab30106
+  OndatoScreenRecorder: 684abc4d6e9fcea5dd566ac366c266dee058a4fa
+  OndatoSDK: 999c3cd6cede5d8ab18dbf09059d65de872e5d6f
+  OndatoSdkReactNative: 5c1d9af8dcedb34fabe817c480124ffcca76de79
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 0735ab4f6b3ec93a7f98187b5da74d7916e2cf4c
   RCTRequired: 8fcc7801bfc433072287b0f24a662e2816e89d0c
@@ -2656,6 +2659,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: b01392348aeea02064c21a2762a42893d82b60a7
 
-PODFILE CHECKSUM: 3c77a603ec4113d1e91781a91f52b0c3fc15bbff
+PODFILE CHECKSUM: a10a39434c51403fb66ab22e0b5ea2e05b452fa3
 
 COCOAPODS: 1.15.2

--- a/ios/OSRNModule.mm
+++ b/ios/OSRNModule.mm
@@ -1,7 +1,12 @@
 #import "OSRNModule.h"
 #import <React/RCTConvert.h>
 #import <OndatoSDK/OndatoSDK-Swift.h>
+
+#if __has_include("OndatoSdkReactNative-Swift.h")
 #import "OndatoSdkReactNative-Swift.h"
+#elif __has_include(<OndatoSdkReactNative/OndatoSdkReactNative-Swift.h>)
+#import <OndatoSdkReactNative/OndatoSdkReactNative-Swift.h>
+#endif
 
 @implementation OSRNModule {
   OndatoModule *ondato;
@@ -28,7 +33,7 @@
   configDict[@"showSuccessWindow"] = @(config.showSuccessWindow());
   configDict[@"removeSelfieFrame"] = @(config.removeSelfieFrame());
   configDict[@"skipRegistrationIfDriverLicense"] = @(config.skipRegistrationIfDriverLicense());
-  
+
   // Handle appearance
   if (auto appearance = config.appearance()) {
     NSMutableDictionary *appearanceDict = [NSMutableDictionary dictionary];
@@ -40,7 +45,7 @@
     appearanceDict[@"textColor"] = appearance->textColor() ?: [NSNull null];
     appearanceDict[@"backgroundColor"] = appearance->backgroundColor() ?: [NSNull null];
     appearanceDict[@"imageTintColor"] = appearance->imageTintColor() ?: [NSNull null];
-    
+
     if (auto consentWindow = appearance->consentWindow()) {
       NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
       // Header
@@ -91,7 +96,7 @@
     }
     configDict[@"appearance"] = appearanceDict;
   }
-  
+
   [ondato startIdentificationWithConfig:configDict resolve:resolve reject:reject];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ondato-sdk-react-native",
-  "version": "2.6.8-newarch.0",
+  "version": "2.6.9-newarch",
   "description": "Ondato React Native SDK: A drop-in component library for capturing identity documents and facial biometrics. Features advanced image quality detection and direct upload to simplify identity verification integration.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/plugin/__tests__/__snapshots__/withIos.test.ts.snap
+++ b/plugin/__tests__/__snapshots__/withIos.test.ts.snap
@@ -44,8 +44,8 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 2.6.8'
-  pod 'OndatoScreenRecorder', '= 2.6.8'
+  pod 'OndatoNFC', '= 2.6.9'
+  pod 'OndatoScreenRecorder', '= 2.6.9'
 
   post_install do |installer|
     react_native_post_install(
@@ -103,7 +103,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 2.6.8'
+  pod 'OndatoNFC', '= 2.6.9'
 
   post_install do |installer|
     react_native_post_install(
@@ -161,7 +161,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoScreenRecorder', '= 2.6.8'
+  pod 'OndatoScreenRecorder', '= 2.6.9'
 
   post_install do |installer|
     react_native_post_install(
@@ -233,7 +233,7 @@ target 'HelloWorld' do
   end
 end
 
-  pod 'OndatoNFC', '= 2.6.8'"
+  pod 'OndatoNFC', '= 2.6.9'"
 `;
 
 exports[`Config Plugin iOS Tests for SDK 54 - addPods skips adding pods when none are enabled 1`] = `

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -1,4 +1,4 @@
-export const ONDATO_VERSION_IOS = '2.6.8';
+export const ONDATO_VERSION_IOS = '2.6.9';
 export const ONDATO_VERSION_ANDROID = '2.6.7';
 export const ONDATO_MAVEN_REPO_URL =
   'https://raw.githubusercontent.com/ondato/ondato-sdk-android/main/repos/';

--- a/plugin/src/withAndroid.ts
+++ b/plugin/src/withAndroid.ts
@@ -119,7 +119,7 @@ export const addDependencies = (
   }
   if (
     enableScreenRecorder &&
-    !buildGradle.includes('com.kyc.ondato:screen-recorder')
+    !buildGradle.includes('com.kyc.ondato:recorder')
   ) {
     dependenciesToAdd.push(screenRecorderDependency);
   }


### PR DESCRIPTION
This PR updates the native SDKs and fixes compatibility issues with iOS projects that use static frameworks.

**Changes**
- iOS: Added support for static framework integration (fixes GH#26)
- iOS: Bumped native SDK to v2.6.9
- Android: Updated optional native dependency name
- Plugin: Updated snapshots to reflect latest SDK changes

**Testing**
- Verified build and runtime on iOS using both dynamic and static framework setups
- Verified Android build with updated dependency
- Manual testing only (no automated CI)

**Notes**
- This PR closes #26 once merged.
- Consumers should rebuild native modules after updating.