### PR TITLE
fix(ios): add legacy bridge fallback for RN 0.77–0.79 (#28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ android/generated
 
 # React Native Nitro Modules
 nitrogen/
+
+# Custom
+*.tgz
+*.sha256

--- a/README.md
+++ b/README.md
@@ -37,10 +37,32 @@ This SDK provides a set of pre-built screens and tools for React Native applicat
 
 ## Compatibility
 
-| Platform     | Version  |
-| :----------- | :------- |
-| React Native | New Arch |
-| Expo SDK     | 53+      |
+| Platform     | Version |
+| :----------- | :------ |
+| React Native | 0.77+   |
+| Expo SDK     | 53+     |
+
+| React Native Version | Architecture              | Status                               |
+| -------------------: | ------------------------- | :----------------------------------- |
+|            **0.80+** | ✅ **New Architecture**   | Fully supported                      |
+|      **0.77 – 0.79** | ⚙️ **New Arch (partial)** | Supported via fallback legacy bridge |
+|           **< 0.77** | ❌                        | Not supported                        |
+
+> **React Native 0.77 – 0.79**
+>
+> The new architecture in these versions uses an outdated TurboModule API.
+> To use the Ondato SDK, you must **disable new arch** in your Podfile:
+>
+> ```ruby
+> use_react_native!(
+>   :path => config[:reactNativePath],
+>   :new_arch_enabled => false # add this line
+> )
+> ```
+>
+> Then run `pod install` again.
+>
+> The package will automatically fall back to the legacy bridge.
 
 ## Prerequisites
 

--- a/ios/OndatoConfiguration.swift
+++ b/ios/OndatoConfiguration.swift
@@ -22,7 +22,7 @@ struct OndatoConfiguration {
   static func fromDictionary(_ dict: NSDictionary) throws -> OndatoConfiguration {
     // Reject Android-only fields
     if dict["showSplashScreen"] != nil || dict["showWaitingScreen"] != nil || dict["showIdentificationWaitingPage"] != nil {
-      throw NSError(domain: "OndatoConfig", code: 1, userInfo: [NSLocalizedDescriptionKey: "Android-only fields (showSplashScreen, showWaitingScreen, showIdentificationWaitingPage) not supported on iOS"])
+      NSLog("[Ondato] Ignoring android-only fields (showSplashScreen, showWaitingScreen, showIdentificationWaitingPage) - they are not supported on iOS");
     }
     
     // Required fields

--- a/ios/OndatoLegacyModule.mm
+++ b/ios/OndatoLegacyModule.mm
@@ -1,0 +1,42 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTLog.h>
+#import <OndatoSDK/OndatoSDK-Swift.h>
+
+#if __has_include("OndatoSdkReactNative-Swift.h")
+#import "OndatoSdkReactNative-Swift.h"
+#elif __has_include(<OndatoSdkReactNative/OndatoSdkReactNative-Swift.h>)
+#import <OndatoSdkReactNative/OndatoSdkReactNative-Swift.h>
+#else
+#error "Could not find the generated Swift header (OndatoSdkReactNative-Swift.h)"
+#endif
+
+#if !RCT_NEW_ARCH_ENABLED   // compile only when the old bridge is active
+
+@interface OndatoLegacyModule : NSObject <RCTBridgeModule>
+@end
+
+@implementation OndatoLegacyModule
+
+RCT_EXPORT_MODULE(OndatoModule);
+
+RCT_EXPORT_METHOD(startIdentification:(NSDictionary *)config
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+    @try {
+      OndatoModule *swiftModule = [OndatoModule new];
+      [swiftModule startIdentificationWithConfig:config
+                                         resolve:resolve
+                                          reject:reject];
+    }
+    @catch (NSException *exception) {
+      RCTLogError(@"[Ondato] startIdentification exception: %@", exception);
+      reject(@"ONDATO_ERROR", exception.reason, nil);
+    }
+  });
+}
+
+@end
+
+#endif // !RCT_NEW_ARCH_ENABLED

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "peerDependencies": {
     "expo": ">=53.0.0",
     "react": "*",
-    "react-native": "*"
+    "react-native": ">=0.77.0"
   },
   "peerDependenciesMeta": {
     "expo": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ondato-sdk-react-native",
-  "version": "2.6.9-newarch",
+  "version": "2.6.10-newarch",
   "description": "Ondato React Native SDK: A drop-in component library for capturing identity documents and facial biometrics. Features advanced image quality detection and direct upload to simplify identity verification integration.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
This PR adds a **legacy bridge fallback** for React Native 0.77 – 0.79 and improves compatibility on iOS when the new architecture is unstable or partially implemented.

It also updates the iOS configuration parser to **ignore Android-only fields** instead of throwing an error.

---

### **Changes**

* **iOS:** Added `OndatoLegacyModule.mm` for RN 0.77–0.79 (requires new arch disabled)
* **iOS:** Replaced config validation throw with `NSLog` to ignore Android-only fields
* **iOS:** Improved compatibility with transitional RN versions (0.77–0.79)
* **Docs:** Updated compatibility and support notes for RN versions 0.77 – 0.82

---

### **Testing**

* Verified build and runtime on:
  * RN 0.77 → works via legacy bridge
  * RN 0.80 + → works via TurboModule (new arch)
* Verified debug build

---

### **Notes**

* This PR **closes #28**.
* For React Native 0.77–0.79, consumers **must disable the new architecture** in `Podfile`:

  ```ruby
  use_react_native!(
    :path => config[:reactNativePath],
    :new_arch_enabled => false # add this line
  )
  ```
* iOS now logs and ignores Android-only config fields (`showSplashScreen`, `showWaitingScreen`, `showIdentificationWaitingPage`) instead of throwing errors.