### PR TITLE
 fix(ios): resolve TurboModule registration for RN 0.77-0.79 new arch enabled projects (GH#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To create a new Expo project, see the [Get Started](https://docs.expo.dev/get-st
 Install Ondato SDK React Native:
 
 ```bash
-npx expo install https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.10-newarch/osrn-v2.6.10-newarch.tgz
+npx expo install https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.11-newarch/osrn-v2.6.11-newarch.tgz
 ```
 
 ### Configure Ondato SDK with config plugin
@@ -162,9 +162,9 @@ npx expo run:ios
 ### Installation
 
 ```sh
-yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.10-newarch/osrn-v2.6.10-newarch.tgz
+yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.11-newarch/osrn-v2.6.11-newarch.tgz
 # or
-npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.10-newarch/osrn-v2.6.10-newarch.tgz
+npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/2.6.11-newarch/osrn-v2.6.11-newarch.tgz
 ```
 
 #### iOS Specific Setup

--- a/ios/OSRNModule.h
+++ b/ios/OSRNModule.h
@@ -1,5 +1,0 @@
-#import <OndatoSpec/OndatoSpec.h>
-
-@interface OSRNModule : NSObject <NativeOndatoModuleSpec>
-
-@end

--- a/ios/OndatoConfiguration.swift
+++ b/ios/OndatoConfiguration.swift
@@ -1,10 +1,3 @@
-//
-//  OndatoConfiguration.swift
-//  Pods
-//
-//  Created by Darius Rainys on 01/09/2025.
-//
-
 import Foundation
 import OndatoSDK
 import React

--- a/ios/OndatoLegacyModule.mm
+++ b/ios/OndatoLegacyModule.mm
@@ -25,7 +25,7 @@ RCT_EXPORT_METHOD(startIdentification:(NSDictionary *)config
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     @try {
-      OndatoModule *swiftModule = [OndatoModule new];
+      OndatoLogic *swiftModule = [OndatoLogic new];
       [swiftModule startIdentificationWithConfig:config
                                          resolve:resolve
                                           reject:reject];

--- a/ios/OndatoLogic.swift
+++ b/ios/OndatoLogic.swift
@@ -1,15 +1,8 @@
-//
-//  OSRNModule.swift
-//  Pods
-//
-//  Created by Darius Rainys on 01/09/2025.
-//
-
 import Foundation
 import OndatoSDK
 import React
 
-@objc public class OndatoModule: NSObject {
+@objc public class OndatoLogic: NSObject {
   private var resolve: RCTPromiseResolveBlock?
   private var reject: RCTPromiseRejectBlock?
   
@@ -57,7 +50,7 @@ import React
   }
 }
 
-extension OndatoModule: OndatoFlowDelegate {
+extension OndatoLogic: OndatoFlowDelegate {
   public func flowDidSucceed(identificationId: String?) {
     finish(with: ["status": "success", "id": identificationId ?? ""])
   }

--- a/ios/OndatoModule.h
+++ b/ios/OndatoModule.h
@@ -1,0 +1,5 @@
+#import <RNOndatoSpec/RNOndatoSpec.h>
+
+@interface OndatoModule : NSObject <NativeOndatoModuleSpec>
+
+@end

--- a/ios/OndatoModule.mm
+++ b/ios/OndatoModule.mm
@@ -1,4 +1,4 @@
-#import "OSRNModule.h"
+#import "OndatoModule.h"
 #import <React/RCTConvert.h>
 #import <OndatoSDK/OndatoSDK-Swift.h>
 
@@ -8,13 +8,13 @@
 #import <OndatoSdkReactNative/OndatoSdkReactNative-Swift.h>
 #endif
 
-@implementation OSRNModule {
-  OndatoModule *ondato;
+@implementation OndatoModule {
+  OndatoLogic *ondato;
 }
 
 - (id)init {
   if (self = [super init]) {
-    ondato = [OndatoModule new];
+    ondato = [OndatoLogic new];
   }
   return self;
 }
@@ -33,7 +33,7 @@
   configDict[@"showSuccessWindow"] = @(config.showSuccessWindow());
   configDict[@"removeSelfieFrame"] = @(config.removeSelfieFrame());
   configDict[@"skipRegistrationIfDriverLicense"] = @(config.skipRegistrationIfDriverLicense());
-
+  
   // Handle appearance
   if (auto appearance = config.appearance()) {
     NSMutableDictionary *appearanceDict = [NSMutableDictionary dictionary];
@@ -45,7 +45,7 @@
     appearanceDict[@"textColor"] = appearance->textColor() ?: [NSNull null];
     appearanceDict[@"backgroundColor"] = appearance->backgroundColor() ?: [NSNull null];
     appearanceDict[@"imageTintColor"] = appearance->imageTintColor() ?: [NSNull null];
-
+    
     if (auto consentWindow = appearance->consentWindow()) {
       NSMutableDictionary *consentDict = [NSMutableDictionary dictionary];
       // Header
@@ -96,7 +96,7 @@
     }
     configDict[@"appearance"] = appearanceDict;
   }
-
+  
   [ondato startIdentificationWithConfig:configDict resolve:resolve reject:reject];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ondato-sdk-react-native",
-  "version": "2.6.10-newarch",
+  "version": "2.6.11-newarch",
   "description": "Ondato React Native SDK: A drop-in component library for capturing identity documents and facial biometrics. Features advanced image quality detection and direct upload to simplify identity verification integration.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -171,18 +171,11 @@
     ]
   },
   "codegenConfig": {
-    "name": "OndatoSpec",
+    "name": "RNOndatoSpec",
     "type": "modules",
     "jsSrcsDir": "src",
     "android": {
       "javaPackageName": "com.ondato"
-    },
-    "ios": {
-      "modules": {
-        "OndatoModule": {
-          "className": "OSRNModule"
-        }
-      }
     }
   },
   "create-react-native-library": {


### PR DESCRIPTION
### Description

This PR resolves TurboModule registration issues on React Native 0.7x and finalizes the unified module structure for iOS.

### Changes

- **iOS:** Removed legacy `OSRNModule` indirection and unified entrypoint as `OndatoModule`
- **iOS:** Renamed `OndatoModule.swift` → `OndatoLogic.swift` for clearer separation of SDK logic
- **iOS:** Updated `codegenConfig` name to `RNOndatoSpec` to prevent SDK symbol collisions
- **iOS:** Removed `ios.modules` override from Codegen configuration — fixes new arch runtime errors on RN 0.77–0.79
- **iOS:** Restored consistent module name export for both architectures
- **Docs:** Updated installtion instructions

### Testing

- Verified build/runtime on RN 0.77, 0.81
- Validated debug configuration

**Closes:** #28 