### PR TITLE
chore: update android sdk version to 3.3.0, add new terms properties,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Install the required dependencies:
 
 ```bash
 npx expo install expo-build-properties
-yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.2.3/osrn-v3.2.3.tgz
+yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.0/osrn-v3.3.0.tgz
 ```
 
 ### Configure Ondato SDK with config plugin
@@ -122,16 +122,16 @@ npx expo run:ios
 
 #### Plugin Options
 
-| Option                           | Type      | Description                                                | Default                                                                                            |
-| -------------------------------- | --------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `enableNfc`                      | `boolean` | Adds NFC support for scanning identification documents. | `false`                                                                                            |
-| `enableScreenRecorder`           | `boolean` | Adds screen recording with audio for verification.      | `false`                                                                                            |
-| `enableDocumentResolver`         | `boolean` | Adds document auto-resolver dependency for Android and OndatoAutocapture Pod for iOS.  | `false`                                                                                            |
-| `ios.nfcUsageDescription`        | `string`  | iOS NFC usage description for `Info.plist`.                | `"This app uses NFC to scan identification documents."`                                            |
-| `ios.cameraUsageDescription`     | `string`  | iOS camera usage description for `Info.plist`.             | `"Required for document and facial capture"`                                                       |
-| `ios.microphoneUsageDescription` | `string`  | iOS microphone usage description for `Info.plist`.         | `"This app uses the microphone to record audio during the screen recording verification process."` |
-| `customLocalizationPath`         | `string`  | Path to a directory with custom localization files.        | `undefined`                                                                                        |
-| `customIllustrationsPath`        | `string`  | Path to a directory with custom illustration files.        | `undefined`                                                                                        |
+| Option                           | Type      | Description                                                                           | Default                                                                                            |
+| -------------------------------- | --------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `enableNfc`                      | `boolean` | Adds NFC support for scanning identification documents.                               | `false`                                                                                            |
+| `enableScreenRecorder`           | `boolean` | Adds screen recording with audio for verification.                                    | `false`                                                                                            |
+| `enableDocumentResolver`         | `boolean` | Adds document auto-resolver dependency for Android and OndatoAutocapture Pod for iOS. | `false`                                                                                            |
+| `ios.nfcUsageDescription`        | `string`  | iOS NFC usage description for `Info.plist`.                                           | `"This app uses NFC to scan identification documents."`                                            |
+| `ios.cameraUsageDescription`     | `string`  | iOS camera usage description for `Info.plist`.                                        | `"Required for document and facial capture"`                                                       |
+| `ios.microphoneUsageDescription` | `string`  | iOS microphone usage description for `Info.plist`.                                    | `"This app uses the microphone to record audio during the screen recording verification process."` |
+| `customLocalizationPath`         | `string`  | Path to a directory with custom localization files.                                   | `undefined`                                                                                        |
+| `customIllustrationsPath`        | `string`  | Path to a directory with custom illustration files.                                   | `undefined`                                                                                        |
 
 ---
 
@@ -298,9 +298,9 @@ await startIdentification({
 ### Installation
 
 ```sh
-yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.2.3/osrn-v3.2.3.tgz
+yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.0/osrn-v3.3.0.tgz
 # or
-npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/3.2.3/osrn-v3.2.3.tgz
+npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.0/osrn-v3.3.0.tgz
 ```
 
 #### iOS Specific Setup
@@ -1077,11 +1077,11 @@ To find the full list of available string keys to override, please refer to the 
     ```groovy
     dependencies {
       // ... other dependencies
-      implementation("com.kyc.ondato:screen-recorder:3.2.2")
+      implementation("com.kyc.ondato:screen-recorder:3.3.0")
       // and/or
-      implementation("com.kyc.ondato:nfc-reader:3.2.2")
+      implementation("com.kyc.ondato:nfc-reader:3.3.0")
       // and/or
-      implementation("com.kyc.ondato:document-autoresolver:3.2.2")
+      implementation("com.kyc.ondato:document-autoresolver:3.3.0")
     }
     ```
 3.  Permissions are handled automatically via Manifest Merge.
@@ -1149,6 +1149,8 @@ export default function App() {
         appearance: {
           /* whitelabel JSON object, see Customization > Styling */
         },
+        requireScrollToEnableTermsButton: true, // Android only
+        termsButtonTimeout: 15000, // Android only
       });
 
       if (result.status === 'success') {
@@ -1213,18 +1215,20 @@ The `startIdentification` function accepts a single configuration object. There 
 
 ### Configuration Options
 
-| Property                          | Type                               | Default      | Platform | Description                                                               |
-| --------------------------------- | ---------------------------------- | ------------ | -------- | ------------------------------------------------------------------------- |
-| **`identityVerificationId`**      | `string`                           | _(Required)_ | All      | The unique ID for the verification session, obtained from the Ondato API. |
-| `mode`                            | `'test'` \| `'live'`               | `'test'`     | All      | Sets the SDK environment.                                                 |
-| `language`                        | `string`                           | `'en'`       | All      | Sets the localization for the SDK (e.g., 'bg', 'ca', 'cs', etc.).         |
-| `logLevel`                        | `'error'` \| `'info'` \| `'debug'` | `'info'`     | All      | Sets the verbosity of logs. See [Logging](#logging) for details.          |
-| `switchPrimaryButtons`            | `boolean`                          | `false`      | All      | Switches primary buttons if true.                                         |
-| `enableNetworkIssuesScreen`       | `boolean`                          | `true`       | All      | Enables network issues screen if true.                                    |
-| `disablePdfFileUpload`            | `boolean`                          | `false`      | All      | Disables PDF file upload if true.                                         |
-| `skipRegistrationIfDriverLicense` | `boolean`                          | `false`      | iOS      | Skips registration if driver's license is used.                           |
-| `showTranslationKeys`             | `boolean`                          | `false`      | iOS      | Shows translation keys if true.                                           |
-| `appearance`                      | `object`                           | `{}`         | All      | An object to customize the colors, fonts, and styles of the UI.           |
+| Property                           | Type                               | Default      | Platform | Description                                                                     |
+| ---------------------------------- | ---------------------------------- | ------------ | -------- | ------------------------------------------------------------------------------- |
+| **`identityVerificationId`**       | `string`                           | _(Required)_ | All      | The unique ID for the verification session, obtained from the Ondato API.       |
+| `mode`                             | `'test'` \| `'live'`               | `'test'`     | All      | Sets the SDK environment.                                                       |
+| `language`                         | `string`                           | `'en'`       | All      | Sets the localization for the SDK (e.g., 'bg', 'ca', 'cs', etc.).               |
+| `logLevel`                         | `'error'` \| `'info'` \| `'debug'` | `'info'`     | All      | Sets the verbosity of logs. See [Logging](#logging) for details.                |
+| `switchPrimaryButtons`             | `boolean`                          | `false`      | All      | Switches primary buttons if true.                                               |
+| `enableNetworkIssuesScreen`        | `boolean`                          | `true`       | All      | Enables network issues screen if true.                                          |
+| `disablePdfFileUpload`             | `boolean`                          | `false`      | All      | Disables PDF file upload if true.                                               |
+| `skipRegistrationIfDriverLicense`  | `boolean`                          | `false`      | iOS      | Skips registration if driver's license is used.                                 |
+| `showTranslationKeys`              | `boolean`                          | `false`      | iOS      | Shows translation keys if true.                                                 |
+| `appearance`                       | `object`                           | `{}`         | All      | An object to customize the colors, fonts, and styles of the UI.                 |
+| `requireScrollToEnableTermsButton` | `boolean`                          | `true`       | Android  | Requires scrolling to the end of consent text before enabling the agree button. |
+| `termsButtonTimeout`               | `number`                           | `10000`      | Android  | Delay in milliseconds before enabling the agree button.                         |
 
 ### Handling the Result
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   // SDK core - required in all cases
-  implementation("com.kyc.ondato:sdk-core:3.2.2")
+  implementation("com.kyc.ondato:sdk-core:3.3.0")
   // Required by Ondato SDK
   implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
 }

--- a/android/src/main/java/com/ondato/OndatoConfiguration.kt
+++ b/android/src/main/java/com/ondato/OndatoConfiguration.kt
@@ -15,7 +15,9 @@ data class OndatoConfiguration(
   val switchPrimaryButtons: Boolean,
   val appearance: String?,
   val logLevel: OndatoLoggingLevel,
-  val fonts: ReadableMap?
+  val fonts: ReadableMap?,
+  val requireScrollToEnableTermsButton: Boolean,
+  val termsButtonTimeout: Long
 ) {
   companion object {
     fun fromReadableMap(map: ReadableMap): OndatoConfiguration {
@@ -68,6 +70,10 @@ data class OndatoConfiguration(
         if (fullFonts?.hasKey("android") == true) fullFonts.getMap("android") else null
       } else null
 
+      // Terms and Conditions button configuration
+      val requireScrollToEnableTermsButton = map.getBoolean("requireScrollToEnableTermsButton")
+      val termsButtonTimeout = map.getDouble("termsButtonTimeout").toLong()
+
       return OndatoConfiguration(
         identityVerificationId = id,
         mode = mode,
@@ -77,7 +83,9 @@ data class OndatoConfiguration(
         switchPrimaryButtons = map.getBoolean("switchPrimaryButtons"),
         appearance = map.getString("appearance"),
         logLevel = logLevel,
-        fonts = androidFonts
+        fonts = androidFonts,
+        requireScrollToEnableTermsButton = requireScrollToEnableTermsButton,
+        termsButtonTimeout = termsButtonTimeout
       )
     }
   }
@@ -90,6 +98,10 @@ data class OndatoConfiguration(
       .disablePdfFileUploadForProofOfAddress(disablePdfFileUpload)
       .setSwitchPrimaryButtons(switchPrimaryButtons)
       .setLoggingLevel(logLevel)
+      .setTermsAndConditionsRules(
+        requireScrollToEnableTermsButton,
+        termsButtonTimeout
+      )
 
     // Apply language if provided
     language?.let { builder.setLanguage(it) }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -112,9 +112,9 @@ dependencies {
   implementation("com.facebook.react:react-android")
 
   // Ondato SDK extra dependencies
-  implementation("com.kyc.ondato:nfc-reader:3.2.2")
-  implementation("com.kyc.ondato:screen-recorder:3.2.2")
-  implementation("com.kyc.ondato:document-autoresolver:3.2.2")
+  implementation("com.kyc.ondato:nfc-reader:3.3.0")
+  implementation("com.kyc.ondato:screen-recorder:3.3.0")
+  implementation("com.kyc.ondato:document-autoresolver:3.3.0")
 
   if (hermesEnabled.toBoolean()) {
     implementation("com.facebook.react:hermes-android")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ondato-sdk-react-native",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Ondato React Native SDK: A drop-in component library for capturing identity documents and facial biometrics. Features advanced image quality detection and direct upload to simplify identity verification integration.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/plugin/__tests__/__snapshots__/withAndroid.test.ts.snap
+++ b/plugin/__tests__/__snapshots__/withAndroid.test.ts.snap
@@ -156,9 +156,9 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.2.2")
-    implementation("com.kyc.ondato:screen-recorder:3.2.2")
-    implementation("com.kyc.ondato:document-autoresolver:3.2.2")
+    implementation("com.kyc.ondato:nfc-reader:3.3.0")
+    implementation("com.kyc.ondato:screen-recorder:3.3.0")
+    implementation("com.kyc.ondato:document-autoresolver:3.3.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -345,7 +345,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:document-autoresolver:3.2.2")
+    implementation("com.kyc.ondato:document-autoresolver:3.3.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -562,8 +562,8 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.2.2")
-    implementation("com.kyc.ondato:screen-recorder:3.2.2")
+    implementation("com.kyc.ondato:nfc-reader:3.3.0")
+    implementation("com.kyc.ondato:screen-recorder:3.3.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -750,7 +750,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.2.2")
+    implementation("com.kyc.ondato:nfc-reader:3.3.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -937,7 +937,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:screen-recorder:3.2.2")
+    implementation("com.kyc.ondato:screen-recorder:3.3.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -1,7 +1,7 @@
 export const MIN_SDK_VERSION = 24;
 export const DEPLOYMENT_TARGET = '15.1';
 
-export const ONDATO_VERSION_ANDROID = '3.2.2';
+export const ONDATO_VERSION_ANDROID = '3.3.0';
 export const ONDATO_VERSION_IOS = '3.2.1';
 
 export const MAVEN_REPOS = [

--- a/src/NativeOndatoModule.ts
+++ b/src/NativeOndatoModule.ts
@@ -96,6 +96,10 @@ export type OndatoConfig = {
   logLevel?: LogLevel;
   /** An object specifying custom fonts to use */
   fonts?: Fonts;
+  /** Require scrolling to the end of consent text before enabling the "agree" button (Android only, defaults to true) */
+  requireScrollToEnableTermsButton?: boolean;
+  /** Delay in milliseconds before enabling the "agree" button (Android only, defaults to 10000) */
+  termsButtonTimeout?: number;
 };
 
 /** Native configuration with defaults applied */
@@ -111,6 +115,8 @@ export type OndatoNativeConfig = {
   appearance?: string;
   logLevel: LogLevel;
   fonts?: Fonts;
+  requireScrollToEnableTermsButton: boolean;
+  termsButtonTimeout: number;
 };
 
 /** Result of the identification process */

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -43,6 +43,8 @@ describe('Ondato SDK Module (index.tsx)', () => {
         enableNetworkIssuesScreen: true,
         disablePdfFileUpload: false,
         skipRegistrationIfDriverLicense: false,
+        requireScrollToEnableTermsButton: true,
+        termsButtonTimeout: 10000,
         showTranslationKeys: false,
         logLevel: 'info',
         fonts: undefined,
@@ -79,6 +81,8 @@ describe('Ondato SDK Module (index.tsx)', () => {
         enableNetworkIssuesScreen: true,
         disablePdfFileUpload: false,
         skipRegistrationIfDriverLicense: false,
+        requireScrollToEnableTermsButton: true,
+        termsButtonTimeout: 10000,
         showTranslationKeys: false,
       });
     });
@@ -102,7 +106,26 @@ describe('Ondato SDK Module (index.tsx)', () => {
         showTranslationKeys: false,
         skipRegistrationIfDriverLicense: false,
         switchPrimaryButtons: false,
+        requireScrollToEnableTermsButton: true,
+        termsButtonTimeout: 10000,
       });
+    });
+
+    it('should pass through requireScrollToEnableTermsButton and termsButtonTimeout when provided', () => {
+      const config = {
+        identityVerificationId: 'test-id-789',
+        requireScrollToEnableTermsButton: false,
+        termsButtonTimeout: 1234,
+      };
+
+      startIdentification(config as OndatoConfig);
+
+      expect(Ondato.startIdentification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requireScrollToEnableTermsButton: false,
+          termsButtonTimeout: 1234,
+        })
+      );
     });
 
     it('should treat empty string language as undefined', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,6 +81,8 @@ const configSchema = z
     enableNetworkIssuesScreen: z.boolean().default(true),
     disablePdfFileUpload: z.boolean().default(false),
     skipRegistrationIfDriverLicense: z.boolean().default(false),
+    requireScrollToEnableTermsButton: z.boolean().default(true),
+    termsButtonTimeout: z.number().default(10000),
     showTranslationKeys: z.boolean().default(false),
     logLevel: z.enum(logLevels as [LogLevel, ...LogLevel[]]).default('info'),
     fonts: z


### PR DESCRIPTION
### v3.2.3 - Android SDK update

### **New**

* Added two new properties (Android only):  `requireScrollToEnableTermsButton`, `termsButtonTimeout`

#### Changes

- **iOS:** No Changes
- **Android:** [Updated to v3.3.0](https://github.com/ondato/ondato-sdk-android/releases/tag/3.3.0)