### PR TITLE
chore(release): 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+### Changed
+### Fixed
+### Removed
+### Deprecated
+### Security
+
+## [3.3.1] - 2026-03-24
+
+### Added
+
+- Added `setSkipRegistrationIfDriverLicense` configuration property on Android.
+- Added `requireScrollToEnableTermsButton` and `termsButtonTimeout` configuration properties on Android.
+
+### Changed
+
+- **iOS:** [Updated native SDK to v3.2.2](https://github.com/ondato/ondato-sdk-ios/releases/tag/3.2.2)
+- **Android:** [Updated native SDK to v3.3.2](https://github.com/ondato/ondato-sdk-android/releases/tag/3.3.2)

--- a/OndatoSdkReactNative.podspec
+++ b/OndatoSdkReactNative.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
-  s.dependency "OndatoSDK", "= 3.2.1"
+  s.dependency "OndatoSDK", "= 3.2.2"
 
   install_modules_dependencies(s)
 end

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Install the required dependencies:
 
 ```bash
 npx expo install expo-build-properties
-yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.0/osrn-v3.3.0.tgz
+yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.1/osrn-v3.3.1.tgz
 ```
 
 ### Configure Ondato SDK with config plugin
@@ -298,9 +298,9 @@ await startIdentification({
 ### Installation
 
 ```sh
-yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.0/osrn-v3.3.0.tgz
+yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.1/osrn-v3.3.1.tgz
 # or
-npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.0/osrn-v3.3.0.tgz
+npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/3.3.1/osrn-v3.3.1.tgz
 ```
 
 #### iOS Specific Setup
@@ -1077,11 +1077,11 @@ To find the full list of available string keys to override, please refer to the 
     ```groovy
     dependencies {
       // ... other dependencies
-      implementation("com.kyc.ondato:screen-recorder:3.3.0")
+      implementation("com.kyc.ondato:screen-recorder:3.3.2")
       // and/or
-      implementation("com.kyc.ondato:nfc-reader:3.3.0")
+      implementation("com.kyc.ondato:nfc-reader:3.3.2")
       // and/or
-      implementation("com.kyc.ondato:document-autoresolver:3.3.0")
+      implementation("com.kyc.ondato:document-autoresolver:3.3.2")
     }
     ```
 3.  Permissions are handled automatically via Manifest Merge.
@@ -1091,11 +1091,11 @@ To find the full list of available string keys to override, please refer to the 
 1.  Add the relevant pods to your `Podfile`:
     ```ruby
     # Podfile
-    pod 'OndatoNFC', '= 3.2.1'
+    pod 'OndatoNFC', '= 3.2.2'
     # and/or
-    pod 'OndatoAutocapture', '= 3.2.1'
+    pod 'OndatoAutocapture', '= 3.2.2'
     # and/or
-    pod 'OndatoScreenRecorder', '= 3.2.1'
+    pod 'OndatoScreenRecorder', '= 3.2.2'
     ```
 2.  Add the necessary permissions to your `Info.plist`:
     ```xml
@@ -1141,10 +1141,10 @@ export default function App() {
         mode: 'test', // Use 'live' for production
         language: 'en', // optional: bg, ca, cs, de, el, en, es, et, fi, fr, hr, hu, it, lt, lv, nl, pl, pt, ro, ru, sk, sl, sq, sv, uk, vi
         logLevel: 'debug', // 'error', 'info' or 'debug'
-        switchPrimaryButtons: false, // iOS and Android
-        enableNetworkIssuesScreen: true, // iOS and Android
-        disablePdfFileUpload: false, // iOS and Android
-        skipRegistrationIfDriverLicense: false, // iOS only
+        switchPrimaryButtons: false,
+        enableNetworkIssuesScreen: true,
+        disablePdfFileUpload: false,
+        skipRegistrationIfDriverLicense: false,
         showTranslationKeys: false, // iOS only
         appearance: {
           /* whitelabel JSON object, see Customization > Styling */
@@ -1224,7 +1224,7 @@ The `startIdentification` function accepts a single configuration object. There 
 | `switchPrimaryButtons`             | `boolean`                          | `false`      | All      | Switches primary buttons if true.                                               |
 | `enableNetworkIssuesScreen`        | `boolean`                          | `true`       | All      | Enables network issues screen if true.                                          |
 | `disablePdfFileUpload`             | `boolean`                          | `false`      | All      | Disables PDF file upload if true.                                               |
-| `skipRegistrationIfDriverLicense`  | `boolean`                          | `false`      | iOS      | Skips registration if driver's license is used.                                 |
+| `skipRegistrationIfDriverLicense`  | `boolean`                          | `false`      | All      | Skips registration if driver's license is used.                                 |
 | `showTranslationKeys`              | `boolean`                          | `false`      | iOS      | Shows translation keys if true.                                                 |
 | `appearance`                       | `object`                           | `{}`         | All      | An object to customize the colors, fonts, and styles of the UI.                 |
 | `requireScrollToEnableTermsButton` | `boolean`                          | `true`       | Android  | Requires scrolling to the end of consent text before enabling the agree button. |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   // SDK core - required in all cases
-  implementation("com.kyc.ondato:sdk-core:3.3.0")
+  implementation("com.kyc.ondato:sdk-core:3.3.2")
   // Required by Ondato SDK
   implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
 }

--- a/android/src/main/java/com/ondato/OndatoConfiguration.kt
+++ b/android/src/main/java/com/ondato/OndatoConfiguration.kt
@@ -13,6 +13,7 @@ data class OndatoConfiguration(
   val enableNetworkIssuesScreen: Boolean,
   val disablePdfFileUpload: Boolean,
   val switchPrimaryButtons: Boolean,
+  val skipRegistrationIfDriverLicense: Boolean,
   val appearance: String?,
   val logLevel: OndatoLoggingLevel,
   val fonts: ReadableMap?,
@@ -64,15 +65,10 @@ data class OndatoConfiguration(
         else -> OndatoLoggingLevel.Info
       }
 
-      // Extract only the 'android' sub-map if present, for flat string-based font handling
       val androidFonts = if (map.hasKey("fonts")) {
         val fullFonts = map.getMap("fonts")
         if (fullFonts?.hasKey("android") == true) fullFonts.getMap("android") else null
       } else null
-
-      // Terms and Conditions button configuration
-      val requireScrollToEnableTermsButton = map.getBoolean("requireScrollToEnableTermsButton")
-      val termsButtonTimeout = map.getDouble("termsButtonTimeout").toLong()
 
       return OndatoConfiguration(
         identityVerificationId = id,
@@ -81,11 +77,12 @@ data class OndatoConfiguration(
         enableNetworkIssuesScreen = map.getBoolean("enableNetworkIssuesScreen"),
         disablePdfFileUpload = map.getBoolean("disablePdfFileUpload"),
         switchPrimaryButtons = map.getBoolean("switchPrimaryButtons"),
+        skipRegistrationIfDriverLicense = map.getBoolean("skipRegistrationIfDriverLicense"),
         appearance = map.getString("appearance"),
         logLevel = logLevel,
         fonts = androidFonts,
-        requireScrollToEnableTermsButton = requireScrollToEnableTermsButton,
-        termsButtonTimeout = termsButtonTimeout
+        requireScrollToEnableTermsButton = map.getBoolean("requireScrollToEnableTermsButton"),
+        termsButtonTimeout = map.getDouble("termsButtonTimeout").toLong()
       )
     }
   }
@@ -97,29 +94,24 @@ data class OndatoConfiguration(
       .enableNetworkIssuesScreen(enableNetworkIssuesScreen)
       .disablePdfFileUploadForProofOfAddress(disablePdfFileUpload)
       .setSwitchPrimaryButtons(switchPrimaryButtons)
+      .setSkipRegistrationIfDriverLicense(skipRegistrationIfDriverLicense)
       .setLoggingLevel(logLevel)
-      .setTermsAndConditionsRules(
-        requireScrollToEnableTermsButton,
-        termsButtonTimeout
-      )
+      .setTermsAndConditionsRules(requireScrollToEnableTermsButton, termsButtonTimeout)
 
-    // Apply language if provided
     language?.let { builder.setLanguage(it) }
 
-    // Apply whitelabel JSON if provided
     appearance?.let { builder.setConfiguration(it) }
 
-    // Dynamically resolve font resource IDs
     fonts?.let { fonts ->
-      val resources = context.resources
-      val packageName = context.packageName
+      val res = context.resources
+      val pkg = context.packageName
       val getFontId = { key: String ->
-        fonts.getString(key)?.let { fontName ->
-          val id = resources.getIdentifier(fontName, "font", packageName)
+        fonts.getString(key)?.let { name ->
+          val id = res.getIdentifier(name, "font", pkg)
           if (id == 0) {
             android.util.Log.w(
               "OndatoModule",
-              "Font resource '$fontName' not found for key '$key'"
+              "Font resource '$name' not found for key '$key'"
             )
             null
           } else {
@@ -128,24 +120,22 @@ data class OndatoConfiguration(
         }
       }
 
-      val heading1Font = getFontId("title")
-      val heading2Font = getFontId("subtitle")
-      val normalFont = getFontId("body")
-      val listFont = getFontId("list")
-      val inputLabelFont = getFontId("inputLabel")
-      val buttonTextFont = getFontId("button")
+      val h1 = getFontId("title")
+      val h2 = getFontId("subtitle")
+      val body = getFontId("body")
+      val list = getFontId("list")
+      val label = getFontId("inputLabel")
+      val btn = getFontId("button")
 
-      // Only set custom fonts if at least one was resolved successfully
-      if (heading1Font != null || heading2Font != null || normalFont != null ||
-        listFont != null || inputLabelFont != null || buttonTextFont != null
-      ) {
+      // Only apply if at least one valid resource ID was resolved
+      if (h1 != null || h2 != null || body != null || list != null || label != null || btn != null) {
         builder.setCustomFonts(
-          heading1FontResource = heading1Font,
-          heading2FontResource = heading2Font,
-          normalFontResource = normalFont,
-          listFontResource = listFont,
-          inputLabelFontResource = inputLabelFont,
-          buttonTextFontResource = buttonTextFont
+          heading1FontResource = h1,
+          heading2FontResource = h2,
+          normalFontResource = body,
+          listFontResource = list,
+          inputLabelFontResource = label,
+          buttonTextFontResource = btn
         )
       }
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -112,9 +112,9 @@ dependencies {
   implementation("com.facebook.react:react-android")
 
   // Ondato SDK extra dependencies
-  implementation("com.kyc.ondato:nfc-reader:3.3.0")
-  implementation("com.kyc.ondato:screen-recorder:3.3.0")
-  implementation("com.kyc.ondato:document-autoresolver:3.3.0")
+  implementation("com.kyc.ondato:nfc-reader:3.3.2")
+  implementation("com.kyc.ondato:screen-recorder:3.3.2")
+  implementation("com.kyc.ondato:document-autoresolver:3.3.2")
 
   if (hermesEnabled.toBoolean()) {
     implementation("com.facebook.react:hermes-android")

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -25,9 +25,9 @@ target 'OndatoSdkReactNativeExample' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'OndatoNFC', '= 3.2.1'
-  pod 'OndatoAutocapture', '= 3.2.1'
-  pod 'OndatoScreenRecorder', '= 3.2.1'
+  pod 'OndatoNFC', '= 3.2.2'
+  pod 'OndatoAutocapture', '= 3.2.2'
+  pod 'OndatoScreenRecorder', '= 3.2.2'
 
   post_install do |installer|
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,18 +8,18 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - OndatoAutocapture (3.2.1)
-  - OndatoNFC (3.2.1)
-  - OndatoScreenRecorder (3.2.1)
-  - OndatoSDK (3.2.1)
-  - OndatoSdkReactNative (3.2.2):
+  - OndatoAutocapture (3.2.2)
+  - OndatoNFC (3.2.2)
+  - OndatoScreenRecorder (3.2.2)
+  - OndatoSDK (3.2.2)
+  - OndatoSdkReactNative (3.3.1):
     - boost
     - DoubleConversion
     - fast_float
     - fmt
     - glog
     - hermes-engine
-    - OndatoSDK (= 3.2.1)
+    - OndatoSDK (= 3.2.2)
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTRequired
@@ -2384,9 +2384,9 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - OndatoAutocapture (= 3.2.1)
-  - OndatoNFC (= 3.2.1)
-  - OndatoScreenRecorder (= 3.2.1)
+  - OndatoAutocapture (= 3.2.2)
+  - OndatoNFC (= 3.2.2)
+  - OndatoScreenRecorder (= 3.2.2)
   - OndatoSdkReactNative (from `../..`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -2621,11 +2621,11 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  OndatoAutocapture: 0723d9ff97762bb3dfbdd6bb61079b28efdc4c9d
-  OndatoNFC: 2bfeaca9160676b840eecaccc7d6313f59ffb598
-  OndatoScreenRecorder: 9d68b01786d2c1cd8ed2fe1d04dc0e7406e91a2d
-  OndatoSDK: 09c26e56ae3b9a0bc3f2e1552518cf07c105e3e0
-  OndatoSdkReactNative: b3e2671e185cdde173dcc8bd3db44345878c9318
+  OndatoAutocapture: 07a6c2b46150c6386a2e62773843bd9d634714fd
+  OndatoNFC: 8fe8cba7bdf7ec7160f04297165c1ae1a80d5b4d
+  OndatoScreenRecorder: 61d7ad43d00599b568eb9d4c39fcefe05862aa4b
+  OndatoSDK: 12306945c6aace0cbc6db3579208c69d26f32a4d
+  OndatoSdkReactNative: 8c796c615549810617ce412f62db91ff5dd0621e
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
@@ -2693,6 +2693,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: fa23995c18b65978347b096d0836f4f5093df545
 
-PODFILE CHECKSUM: 909f5a743b61dadfa751f745fc39959e546ab5a9
+PODFILE CHECKSUM: 174bb3b2ddaf6ff422e4863158e7f9cd22169971
 
 COCOAPODS: 1.15.2

--- a/ios/OndatoLogic.swift
+++ b/ios/OndatoLogic.swift
@@ -56,12 +56,12 @@ import React
         }
       }
       
-      // Apply provided fonts
       if let fontsDict = config["fonts"] as? [String: Any] {
         self.applyCustomFonts(fontsDict: fontsDict)
       }
       
-      // Apply custom illustrations
+      self.applyCustomAnimations()
+      
       self.applyCustomIllustrations()
       
       // Present view controller
@@ -166,10 +166,23 @@ extension OndatoLogic: OndatoFlowDelegate {
     }
   }
   
+  private func applyCustomAnimations() {
+    var resources = Ondato.sdk.configuration.resources
+    var animations = resources.animations
+    
+    // Maps to: OndatoAnimations.waitingScreenAnimationFilePath
+    let animationName = "ondato.animations.waitingScreenAnimation"
+    if let animationPath = Bundle.main.path(forResource: animationName, ofType: "json") {
+      animations.waitingScreenAnimationFilePath = animationPath
+      
+      resources.animations = animations
+      Ondato.sdk.configuration.resources = resources
+    }
+  }
+  
   private func applyCustomIllustrations() {
-    let resources = Ondato.sdk.configuration.resources
+    var resources = Ondato.sdk.configuration.resources
     let images = resources.images
-    let animations = resources.animations
     
     // --- Part A: Simple Top-Level Images ---
     // Maps to: OndatoImages.backButton, .closeButton, .warning
@@ -286,13 +299,6 @@ extension OndatoLogic: OndatoFlowDelegate {
     
     if !customNFCInstructions.isEmpty {
       images.nfcCaptureInstructions = customNFCInstructions
-    }
-    
-    // --- Part G: Lottie Animations ---
-    // Maps to: OndatoAnimations.waitingScreenAnimationFilePath
-    let animationName = "ondato.animations.waitingScreenAnimation"
-    if let animationPath = Bundle.main.path(forResource: animationName, ofType: "json") {
-      animations.waitingScreenAnimationFilePath = animationPath
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ondato-sdk-react-native",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Ondato React Native SDK: A drop-in component library for capturing identity documents and facial biometrics. Features advanced image quality detection and direct upload to simplify identity verification integration.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/plugin/__tests__/__snapshots__/withAndroid.test.ts.snap
+++ b/plugin/__tests__/__snapshots__/withAndroid.test.ts.snap
@@ -156,9 +156,9 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.3.0")
-    implementation("com.kyc.ondato:screen-recorder:3.3.0")
-    implementation("com.kyc.ondato:document-autoresolver:3.3.0")
+    implementation("com.kyc.ondato:nfc-reader:3.3.2")
+    implementation("com.kyc.ondato:screen-recorder:3.3.2")
+    implementation("com.kyc.ondato:document-autoresolver:3.3.2")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -345,7 +345,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:document-autoresolver:3.3.0")
+    implementation("com.kyc.ondato:document-autoresolver:3.3.2")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -562,8 +562,8 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.3.0")
-    implementation("com.kyc.ondato:screen-recorder:3.3.0")
+    implementation("com.kyc.ondato:nfc-reader:3.3.2")
+    implementation("com.kyc.ondato:screen-recorder:3.3.2")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -750,7 +750,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.3.0")
+    implementation("com.kyc.ondato:nfc-reader:3.3.2")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -937,7 +937,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:screen-recorder:3.3.0")
+    implementation("com.kyc.ondato:screen-recorder:3.3.2")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 

--- a/plugin/__tests__/__snapshots__/withIos.test.ts.snap
+++ b/plugin/__tests__/__snapshots__/withIos.test.ts.snap
@@ -44,8 +44,8 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.2.1'
-  pod 'OndatoScreenRecorder', '= 3.2.1'
+  pod 'OndatoNFC', '= 3.2.2'
+  pod 'OndatoScreenRecorder', '= 3.2.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -103,9 +103,9 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.2.1'
-  pod 'OndatoScreenRecorder', '= 3.2.1'
-  pod 'OndatoAutocapture', '= 3.2.1'
+  pod 'OndatoNFC', '= 3.2.2'
+  pod 'OndatoScreenRecorder', '= 3.2.2'
+  pod 'OndatoAutocapture', '= 3.2.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -163,7 +163,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoAutocapture', '= 3.2.1'
+  pod 'OndatoAutocapture', '= 3.2.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -221,7 +221,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.2.1'
+  pod 'OndatoNFC', '= 3.2.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -279,7 +279,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoScreenRecorder', '= 3.2.1'
+  pod 'OndatoScreenRecorder', '= 3.2.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -351,7 +351,7 @@ target 'HelloWorld' do
   end
 end
 
-  pod 'OndatoNFC', '= 3.2.1'"
+  pod 'OndatoNFC', '= 3.2.2'"
 `;
 
 exports[`Config Plugin iOS Tests for SDK 54 - addPods skips adding duplicate document resolver pod 1`] = `
@@ -408,7 +408,7 @@ target 'HelloWorld' do
   end
 end
 
-  pod 'OndatoAutocapture', '= 3.2.1'"
+  pod 'OndatoAutocapture', '= 3.2.2'"
 `;
 
 exports[`Config Plugin iOS Tests for SDK 54 - addPods skips adding pods when none are enabled 1`] = `

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -1,8 +1,8 @@
 export const MIN_SDK_VERSION = 24;
 export const DEPLOYMENT_TARGET = '15.1';
 
-export const ONDATO_VERSION_ANDROID = '3.3.0';
-export const ONDATO_VERSION_IOS = '3.2.1';
+export const ONDATO_VERSION_ANDROID = '3.3.2';
+export const ONDATO_VERSION_IOS = '3.2.2';
 
 export const MAVEN_REPOS = [
   'https://gitlab.com/api/v4/projects/65297321/packages/maven',

--- a/src/NativeOndatoModule.ts
+++ b/src/NativeOndatoModule.ts
@@ -80,13 +80,13 @@ export type OndatoConfig = {
   mode?: Mode;
   /** Language code for localization */
   language?: Language;
-  /** Switch primary buttons (shared, defaults to false) */
+  /** Switch primary buttons (defaults to false) */
   switchPrimaryButtons?: boolean;
-  /** Enable network issues screen (shared, defaults to true) */
+  /** Enable network issues screen (defaults to true) */
   enableNetworkIssuesScreen?: boolean;
-  /** Disable PDF file upload (shared, defaults to false) */
+  /** Disable PDF file upload (defaults to false) */
   disablePdfFileUpload?: boolean;
-  /** Skip registration if driver’s license (iOS only, defaults to false) */
+  /** Skip registration if driver’s license (defaults to false) */
   skipRegistrationIfDriverLicense?: boolean;
   /** Show translation keys (iOS only, defaults to false) */
   showTranslationKeys?: boolean;


### PR DESCRIPTION
## 3.3.1

### Added

- Added `setSkipRegistrationIfDriverLicense` configuration property on Android.
- Added `requireScrollToEnableTermsButton` and `termsButtonTimeout` configuration properties on Android.

### Changed

- **iOS:** [Updated native SDK to v3.2.2](https://github.com/ondato/ondato-sdk-ios/releases/tag/3.2.2)
- **Android:** [Updated native SDK to v3.3.2](https://github.com/ondato/ondato-sdk-android/releases/tag/3.3.2)