### PR TITLE
chore: sync release v3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ All notable changes to this project will be documented in this file.
 
 ### Security
 
+## [3.5.2] - 2026-07-13
+
+### Changed
+
+- **Android:** [Updated native SDK to v3.5.0 from v3.5.0rn-beta01](https://github.com/ondato/ondato-sdk-android/releases/tag/3.5.0)
+- **Android:** Documented bare React Native minimum build requirements: `minSdkVersion` 24+, `compileSdkVersion` 37+, Kotlin 2.2.0+, and matching `kotlin-gradle-plugin` when configured manually.
+- **iOS:** [Updated native SDK to v3.5.2](https://github.com/ondato/ondato-sdk-ios/releases/tag/3.5.2)
+
 ## [3.5.1] - 2026-06-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The Ondato SDK for React Native can be integrated into Expo projects using a [de
 
 **Note**: The Ondato SDK for React Native cannot be used in the pre-compiled [Expo Go app](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because it includes native code that is not compiled into Expo Go.
 
+When you use the Ondato Expo config plugin, it applies the native build settings and dependency wiring for you, including the Android build properties, the Kotlin Gradle plugin version, and the iOS deployment target. In Expo projects, you should usually only need to update the plugin configuration and re-run `expo prebuild`.
+
 To create a new Expo project, see the [Get Started](https://docs.expo.dev/get-started/create-a-project/) guide in the Expo documentation.
 
 ### Installation
@@ -78,7 +80,7 @@ Install the required dependencies:
 
 ```bash
 npx expo install expo-build-properties
-yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.5.1/osrn-v3.5.1.tgz
+yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.5.2/osrn-v3.5.2.tgz
 ```
 
 > [!IMPORTANT]
@@ -307,9 +309,9 @@ await startIdentification({
 ### Installation
 
 ```sh
-yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.5.1/osrn-v3.5.1.tgz
+yarn add https://github.com/ondato/ondato-sdk-react-native/releases/download/3.5.2/osrn-v3.5.2.tgz
 # or
-npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/3.5.1/osrn-v3.5.1.tgz
+npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/3.5.2/osrn-v3.5.2.tgz
 ```
 
 > [!IMPORTANT]
@@ -333,7 +335,8 @@ npm install https://github.com/ondato/ondato-sdk-react-native/releases/download/
 
 #### Android Specific Setup
 
-No native changes are required for the core functionality to work.
+1.  **Match the SDK build settings:** Ensure your project uses at least `minSdkVersion` 24, `compileSdkVersion` 37 or above, Kotlin `2.2.0` or above, and a matching `kotlin-gradle-plugin` version in your project-level `android/build.gradle` file if it is set manually.
+2.  **Add optional module dependencies only if needed:** The core SDK works without extra Android dependencies, but NFC, screen recorder, and document resolver still need the Maven repositories and Gradle dependencies listed below.
 
 ### Customization
 
@@ -1105,11 +1108,11 @@ To find the full list of available string keys to override, please refer to the 
     ```groovy
     dependencies {
       // ... other dependencies
-      implementation("com.kyc.ondato:screen-recorder:3.5.0rn-beta01")
+      implementation("com.kyc.ondato:screen-recorder:3.5.0")
       // and/or
-      implementation("com.kyc.ondato:nfc-reader:3.5.0rn-beta01")
+      implementation("com.kyc.ondato:nfc-reader:3.5.0")
       // and/or
-      implementation("com.kyc.ondato:document-autoresolver:3.5.0rn-beta01")
+      implementation("com.kyc.ondato:document-autoresolver:3.5.0")
     }
     ```
 3.  Permissions are handled automatically via Manifest Merge.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
   ext.Ondato = [
-    kotlinVersion: "2.0.21",
+    kotlinVersion: "2.2.0",
     minSdkVersion: 24,
-    compileSdkVersion: 36
+    compileSdkVersion: 37
   ]
 
   ext.getExtOrDefault = { prop ->
@@ -50,7 +50,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
 
   // SDK core - required in all cases
-  implementation("com.kyc.ondato:sdk-core:3.5.0rn-beta01")
+  implementation("com.kyc.ondato:sdk-core:3.5.0")
   // Required by Ondato SDK
   implementation "com.squareup.okhttp3:logging-interceptor:4.12.0"
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -112,9 +112,9 @@ dependencies {
     implementation("com.facebook.react:react-android")
 
     // Ondato SDK extra dependencies
-    implementation("com.kyc.ondato:nfc-reader:3.5.0rn-beta01")
-    implementation("com.kyc.ondato:screen-recorder:3.5.0rn-beta01")
-    implementation("com.kyc.ondato:document-autoresolver:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:nfc-reader:3.5.0")
+    implementation("com.kyc.ondato:screen-recorder:3.5.0")
+    implementation("com.kyc.ondato:document-autoresolver:3.5.0")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     compileSdkVersion = 37
     targetSdkVersion = 37
     ndkVersion = "27.1.12297006"
-    kotlinVersion = "2.1.20"
+    kotlinVersion = "2.2.0"
   }
   repositories {
     google()
@@ -14,7 +14,7 @@ buildscript {
   dependencies {
     classpath("com.android.tools.build:gradle")
     classpath("com.facebook.react:react-native-gradle-plugin")
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
   }
 }
 

--- a/example/ios/OndatoSdkReactNativeExample.xcodeproj/project.pbxproj
+++ b/example/ios/OndatoSdkReactNativeExample.xcodeproj/project.pbxproj
@@ -195,13 +195,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OndatoSdkReactNativeExample/Pods-OndatoSdkReactNativeExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OndatoSdkReactNativeExample/Pods-OndatoSdkReactNativeExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -238,13 +234,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OndatoSdkReactNativeExample/Pods-OndatoSdkReactNativeExample-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-OndatoSdkReactNativeExample/Pods-OndatoSdkReactNativeExample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -23,9 +23,9 @@ target 'OndatoSdkReactNativeExample' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'OndatoNFC', '= 3.5.1'
-  pod 'OndatoAutocapture', '= 3.5.1'
-  pod 'OndatoScreenRecorder', '= 3.5.1'
+  pod 'OndatoNFC', '= 3.5.2'
+  pod 'OndatoAutocapture', '= 3.5.2'
+  pod 'OndatoScreenRecorder', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,11 +3,11 @@ PODS:
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
-  - OndatoAutocapture (3.5.1)
-  - OndatoNFC (3.5.1)
-  - OndatoScreenRecorder (3.5.1)
+  - OndatoAutocapture (3.5.2)
+  - OndatoNFC (3.5.2)
+  - OndatoScreenRecorder (3.5.2)
   - OndatoSDK-Core (3.5.1)
-  - OndatoSdkReactNative (3.5.0):
+  - OndatoSdkReactNative (3.5.1):
     - hermes-engine
     - OndatoSDK-Core (= 3.5.1)
     - RCTRequired
@@ -1848,9 +1848,9 @@ PODS:
 DEPENDENCIES:
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - OndatoAutocapture (= 3.5.1)
-  - OndatoNFC (= 3.5.1)
-  - OndatoScreenRecorder (= 3.5.1)
+  - OndatoAutocapture (= 3.5.2)
+  - OndatoNFC (= 3.5.2)
+  - OndatoScreenRecorder (= 3.5.2)
   - OndatoSdkReactNative (from `../..`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
   - RCTRequired (from `../node_modules/react-native/Libraries/Required`)
@@ -2089,11 +2089,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
   hermes-engine: 24c42e09f301d657ca85dd4eae151df3c578aaf0
-  OndatoAutocapture: 46919d723aec0070542f53c94515d41f554bb31c
-  OndatoNFC: 04ab4ea2614460c888609afdd229170a50106341
-  OndatoScreenRecorder: 4801337e5005fb15f71f64111d719b406f27c4b0
+  OndatoAutocapture: 10464291d7b8226e14d5758ff0f097e1578c2646
+  OndatoNFC: f45f88455dcab4a2f5014c4ef5570e7ecabccb9e
+  OndatoScreenRecorder: 9aa62c88faef2a5b6bd77d6d4d36ad3d4ef6b669
   OndatoSDK-Core: 1c1faeadb2cc1a630e86529218aadc1dcbdd65cb
-  OndatoSdkReactNative: 4e4efd417eb9cf26d6ac2ff702f390628b082a46
+  OndatoSdkReactNative: fef6ca11c4a5f42f71b81db2baba43d0e9d7ab9a
   RCTDeprecation: 3bb167081b134461cfeb875ff7ae1945f8635257
   RCTRequired: 74839f55d5058a133a0bc4569b0afec750957f64
   RCTSwiftUI: 87a316382f3eab4dd13d2a0d0fd2adcce917361a
@@ -2167,6 +2167,6 @@ SPEC CHECKSUMS:
   ReactNativeDependencies: 70ffee01d8f014106466790b97095fac449c495e
   Yoga: cc155241ea30670878e270d52d74cf29487c4bbb
 
-PODFILE CHECKSUM: 2822fd9b9dc1ad518a044dc043b3ce021929cbb5
+PODFILE CHECKSUM: 2e73a2f4a8bc264841595d7fe8c4c445df330ff4
 
 COCOAPODS: 1.15.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ondato-sdk-react-native",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Ondato React Native SDK: A drop-in component library for capturing identity documents and facial biometrics. Features advanced image quality detection and direct upload to simplify identity verification integration.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/plugin/__tests__/__snapshots__/withAndroid.test.ts.snap
+++ b/plugin/__tests__/__snapshots__/withAndroid.test.ts.snap
@@ -156,9 +156,9 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.5.0rn-beta01")
-    implementation("com.kyc.ondato:screen-recorder:3.5.0rn-beta01")
-    implementation("com.kyc.ondato:document-autoresolver:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:nfc-reader:3.5.0")
+    implementation("com.kyc.ondato:screen-recorder:3.5.0")
+    implementation("com.kyc.ondato:document-autoresolver:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -345,7 +345,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:document-autoresolver:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:document-autoresolver:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -562,8 +562,8 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.5.0rn-beta01")
-    implementation("com.kyc.ondato:screen-recorder:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:nfc-reader:3.5.0")
+    implementation("com.kyc.ondato:screen-recorder:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -750,7 +750,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:nfc-reader:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -937,7 +937,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:screen-recorder:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:screen-recorder:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -1310,9 +1310,9 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.5.0rn-beta01")
-    implementation("com.kyc.ondato:screen-recorder:3.5.0rn-beta01")
-    implementation("com.kyc.ondato:document-autoresolver:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:nfc-reader:3.5.0")
+    implementation("com.kyc.ondato:screen-recorder:3.5.0")
+    implementation("com.kyc.ondato:document-autoresolver:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -1499,7 +1499,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:document-autoresolver:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:document-autoresolver:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -1716,8 +1716,8 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.5.0rn-beta01")
-    implementation("com.kyc.ondato:screen-recorder:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:nfc-reader:3.5.0")
+    implementation("com.kyc.ondato:screen-recorder:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -1904,7 +1904,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:nfc-reader:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:nfc-reader:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
@@ -2091,7 +2091,7 @@ android {
 }
 
 dependencies {
-    implementation("com.kyc.ondato:screen-recorder:3.5.0rn-beta01")
+    implementation("com.kyc.ondato:screen-recorder:3.5.0")
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 

--- a/plugin/__tests__/__snapshots__/withIos.test.ts.snap
+++ b/plugin/__tests__/__snapshots__/withIos.test.ts.snap
@@ -44,8 +44,8 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.5.1'
-  pod 'OndatoScreenRecorder', '= 3.5.1'
+  pod 'OndatoNFC', '= 3.5.2'
+  pod 'OndatoScreenRecorder', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -103,9 +103,9 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.5.1'
-  pod 'OndatoScreenRecorder', '= 3.5.1'
-  pod 'OndatoAutocapture', '= 3.5.1'
+  pod 'OndatoNFC', '= 3.5.2'
+  pod 'OndatoScreenRecorder', '= 3.5.2'
+  pod 'OndatoAutocapture', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -163,7 +163,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoAutocapture', '= 3.5.1'
+  pod 'OndatoAutocapture', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -221,7 +221,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.5.1'
+  pod 'OndatoNFC', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -279,7 +279,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoScreenRecorder', '= 3.5.1'
+  pod 'OndatoScreenRecorder', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -351,7 +351,7 @@ target 'HelloWorld' do
   end
 end
 
-  pod 'OndatoNFC', '= 3.5.1'"
+  pod 'OndatoNFC', '= 3.5.2'"
 `;
 
 exports[`Config Plugin iOS Tests for SDK 54 - addPods skips adding duplicate document resolver pod 1`] = `
@@ -408,7 +408,7 @@ target 'HelloWorld' do
   end
 end
 
-  pod 'OndatoAutocapture', '= 3.5.1'"
+  pod 'OndatoAutocapture', '= 3.5.2'"
 `;
 
 exports[`Config Plugin iOS Tests for SDK 54 - addPods skips adding pods when none are enabled 1`] = `
@@ -523,8 +523,8 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.5.1'
-  pod 'OndatoScreenRecorder', '= 3.5.1'
+  pod 'OndatoNFC', '= 3.5.2'
+  pod 'OndatoScreenRecorder', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -594,9 +594,9 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.5.1'
-  pod 'OndatoScreenRecorder', '= 3.5.1'
-  pod 'OndatoAutocapture', '= 3.5.1'
+  pod 'OndatoNFC', '= 3.5.2'
+  pod 'OndatoScreenRecorder', '= 3.5.2'
+  pod 'OndatoAutocapture', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -666,7 +666,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoAutocapture', '= 3.5.1'
+  pod 'OndatoAutocapture', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -736,7 +736,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoNFC', '= 3.5.1'
+  pod 'OndatoNFC', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -806,7 +806,7 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  pod 'OndatoScreenRecorder', '= 3.5.1'
+  pod 'OndatoScreenRecorder', '= 3.5.2'
 
   post_install do |installer|
     react_native_post_install(
@@ -890,7 +890,7 @@ target 'HelloWorld' do
   end
 end
 
-  pod 'OndatoNFC', '= 3.5.1'"
+  pod 'OndatoNFC', '= 3.5.2'"
 `;
 
 exports[`Config Plugin iOS Tests for SDK 56 - addPods skips adding duplicate document resolver pod 1`] = `
@@ -959,7 +959,7 @@ target 'HelloWorld' do
   end
 end
 
-  pod 'OndatoAutocapture', '= 3.5.1'"
+  pod 'OndatoAutocapture', '= 3.5.2'"
 `;
 
 exports[`Config Plugin iOS Tests for SDK 56 - addPods skips adding pods when none are enabled 1`] = `

--- a/plugin/__tests__/withBuildProperties.test.ts
+++ b/plugin/__tests__/withBuildProperties.test.ts
@@ -1,0 +1,170 @@
+import { it, describe, expect, jest, beforeEach } from '@jest/globals';
+
+type BuildGradleConfig = {
+  modResults: {
+    language: string;
+    contents: string;
+  };
+};
+
+let capturedBuildGradleCallback:
+  | ((config: BuildGradleConfig) => BuildGradleConfig)
+  | undefined;
+
+jest.mock('expo/config-plugins', () => {
+  const actualConfigPlugins = jest.requireActual(
+    'expo/config-plugins'
+  ) as Record<string, unknown>;
+
+  return {
+    ...actualConfigPlugins,
+    withProjectBuildGradle: jest.fn((config, callback) => {
+      capturedBuildGradleCallback = callback as (
+        config: BuildGradleConfig
+      ) => BuildGradleConfig;
+
+      return config;
+    }),
+  };
+});
+jest.mock('expo-build-properties', () => ({
+  withBuildProperties: jest.fn((config) => config),
+}));
+
+import { withBuildProperties } from 'expo-build-properties';
+import { withProjectBuildGradle } from 'expo/config-plugins';
+
+import {
+  COMPILE_SDK_VERSION,
+  DEPLOYMENT_TARGET,
+  KOTLIN_VERSION,
+  MIN_SDK_VERSION,
+} from '../src/constants';
+import { withOndatoBuildProperties } from '../src/withBuildProperties';
+
+const withBuildPropertiesMock = withBuildProperties as jest.MockedFunction<
+  typeof withBuildProperties
+>;
+const withProjectBuildGradleMock =
+  withProjectBuildGradle as jest.MockedFunction<typeof withProjectBuildGradle>;
+
+function runPluginAndGetGradleCallback() {
+  capturedBuildGradleCallback = undefined;
+
+  const expoConfig = {} as Parameters<typeof withOndatoBuildProperties>[0];
+
+  withOndatoBuildProperties(expoConfig);
+
+  expect(withProjectBuildGradleMock).toHaveBeenCalledTimes(1);
+  expect(capturedBuildGradleCallback).toBeDefined();
+
+  return capturedBuildGradleCallback!;
+}
+
+describe('withOndatoBuildProperties', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedBuildGradleCallback = undefined;
+  });
+
+  it('passes the expected Expo build properties', () => {
+    runPluginAndGetGradleCallback();
+
+    expect(withBuildPropertiesMock).toHaveBeenCalledWith(
+      {},
+      {
+        android: {
+          minSdkVersion: MIN_SDK_VERSION,
+          kotlinVersion: KOTLIN_VERSION,
+          compileSdkVersion: COMPILE_SDK_VERSION,
+        },
+        ios: {
+          deploymentTarget: DEPLOYMENT_TARGET,
+        },
+      }
+    );
+  });
+
+  it('updates kotlin gradle plugin dependency when build.gradle uses groovy syntax', () => {
+    const applyBuildGradlePatch = runPluginAndGetGradleCallback();
+
+    const config: BuildGradleConfig = {
+      modResults: {
+        language: 'groovy',
+        contents: `buildscript {
+  dependencies {
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin'
+  }
+}`,
+      },
+    };
+
+    const result = applyBuildGradlePatch(config);
+
+    expect(result.modResults.contents).toContain(
+      `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}"`
+    );
+    expect(result.modResults.contents).not.toContain(
+      "classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin'"
+    );
+  });
+
+  it('updates kotlin gradle plugin dependency when build.gradle uses kt syntax', () => {
+    const applyBuildGradlePatch = runPluginAndGetGradleCallback();
+
+    const config: BuildGradleConfig = {
+      modResults: {
+        language: 'kt',
+        contents: `buildscript {
+  dependencies {
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+  }
+}`,
+      },
+    };
+
+    const result = applyBuildGradlePatch(config);
+
+    expect(result.modResults.contents).toContain(
+      `classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${KOTLIN_VERSION}")`
+    );
+  });
+
+  it('does not downgrade an existing newer kotlin gradle plugin version', () => {
+    const applyBuildGradlePatch = runPluginAndGetGradleCallback();
+
+    const config: BuildGradleConfig = {
+      modResults: {
+        language: 'groovy',
+        contents: `buildscript {
+  dependencies {
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0")
+  }
+}`,
+      },
+    };
+
+    const result = applyBuildGradlePatch(config);
+
+    expect(result.modResults.contents).toBe(config.modResults.contents);
+  });
+
+  it('leaves non-groovy and non-kt build files unchanged', () => {
+    const applyBuildGradlePatch = runPluginAndGetGradleCallback();
+
+    const config: BuildGradleConfig = {
+      modResults: {
+        language: 'text',
+        contents: `buildscript {
+  dependencies {
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin'
+  }
+}`,
+      },
+    };
+
+    const result = applyBuildGradlePatch(config);
+
+    expect(result.modResults.contents).toBe(config.modResults.contents);
+  });
+});

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -1,8 +1,10 @@
 export const MIN_SDK_VERSION = 24;
 export const DEPLOYMENT_TARGET = '16.4';
+export const KOTLIN_VERSION = '2.2.0';
+export const COMPILE_SDK_VERSION = 37;
 
-export const ONDATO_VERSION_ANDROID = '3.5.0rn-beta01';
-export const ONDATO_VERSION_IOS = '3.5.1';
+export const ONDATO_VERSION_ANDROID = '3.5.0';
+export const ONDATO_VERSION_IOS = '3.5.2';
 
 export const MAVEN_REPOS = [
   'https://gitlab.com/api/v4/projects/65297321/packages/maven',

--- a/plugin/src/withBuildProperties.ts
+++ b/plugin/src/withBuildProperties.ts
@@ -1,14 +1,96 @@
-import { type ConfigPlugin } from 'expo/config-plugins';
+import { type ConfigPlugin, withProjectBuildGradle } from 'expo/config-plugins';
 import { withBuildProperties } from 'expo-build-properties';
-import { MIN_SDK_VERSION, DEPLOYMENT_TARGET } from './constants';
+import {
+  MIN_SDK_VERSION,
+  DEPLOYMENT_TARGET,
+  KOTLIN_VERSION,
+  COMPILE_SDK_VERSION,
+} from './constants';
 
 export const withOndatoBuildProperties: ConfigPlugin = (config) => {
-  return withBuildProperties(config, {
+  config = withBuildProperties(config, {
     android: {
       minSdkVersion: MIN_SDK_VERSION,
+      kotlinVersion: KOTLIN_VERSION,
+      compileSdkVersion: COMPILE_SDK_VERSION,
     },
     ios: {
       deploymentTarget: DEPLOYMENT_TARGET,
     },
   });
+  config = withKotlinGradlePluginPatch(config);
+
+  return config;
 };
+
+const withKotlinGradlePluginPatch: ConfigPlugin = (configuration) => {
+  return withProjectBuildGradle(configuration, (config) => {
+    if (
+      config.modResults.language === 'groovy' ||
+      config.modResults.language === 'kt'
+    ) {
+      const kotlinVersion = KOTLIN_VERSION;
+
+      // Matches: classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+      const searchRegex =
+        /classpath\s*\(\s*['"]org\.jetbrains\.kotlin:kotlin-gradle-plugin(?::([0-9]+(?:\.[0-9]+)*))?['"]\s*\)/g;
+      const replacement = `classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")`;
+
+      // Matches: classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin' (no parentheses)
+      const searchRegexNoParens =
+        /classpath\s+['"]org\.jetbrains\.kotlin:kotlin-gradle-plugin(?::([0-9]+(?:\.[0-9]+)*))?['"]/g;
+      const replacementNoParens = `classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"`;
+
+      let newContents = config.modResults.contents.replace(
+        searchRegex,
+        (match, existingVersion?: string) => {
+          if (
+            existingVersion &&
+            compareVersions(existingVersion, kotlinVersion) >= 0
+          ) {
+            return match;
+          }
+
+          return replacement;
+        }
+      );
+      newContents = newContents.replace(
+        searchRegexNoParens,
+        (match, existingVersion?: string) => {
+          if (
+            existingVersion &&
+            compareVersions(existingVersion, kotlinVersion) >= 0
+          ) {
+            return match;
+          }
+
+          return replacementNoParens;
+        }
+      );
+
+      config.modResults.contents = newContents;
+    }
+    return config;
+  });
+};
+
+function compareVersions(firstVersion: string, secondVersion: string): number {
+  const firstParts = firstVersion.split('.').map(Number);
+  const secondParts = secondVersion.split('.').map(Number);
+  const partsLength = Math.max(firstParts.length, secondParts.length);
+
+  for (let index = 0; index < partsLength; index += 1) {
+    const firstPart = firstParts[index] ?? 0;
+    const secondPart = secondParts[index] ?? 0;
+
+    if (firstPart > secondPart) {
+      return 1;
+    }
+
+    if (firstPart < secondPart) {
+      return -1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
### Changed

- **Android:** [Updated native SDK to v3.5.0 from v3.5.0rn-beta01](https://github.com/ondato/ondato-sdk-android/releases/tag/3.5.0)
- **Android:** Documented bare React Native minimum build requirements: `minSdkVersion` 24+, `compileSdkVersion` 37+, Kotlin 2.2.0+, and matching `kotlin-gradle-plugin` when configured manually.
- **iOS:** [Updated native SDK to v3.5.2](https://github.com/ondato/ondato-sdk-ios/releases/tag/3.5.2)